### PR TITLE
fix(packages): align deb/rpm dockerfile systemd unit path with embedd…

### DIFF
--- a/packages/Dockerfile_debian_based
+++ b/packages/Dockerfile_debian_based
@@ -32,7 +32,7 @@ COPY ./packages/debian-based/. ${PACK_DIR}/
 COPY --from=omnibus /opt/. ${PACK_DIR}/opt/
 
 RUN cd ${PACK_DIR} && mkdir -p etc/systemd/system && \
-    cp -a opt/csghub/etc/csghub/templates/system etc/systemd/system
+    cp -a opt/csghub/embedded/etc/csghub/csghub-runsvdir.service etc/systemd/system/
 
 ARG TARGETARCH
 ARG CSGHUB_VERSION

--- a/packages/Dockerfile_rhel_based
+++ b/packages/Dockerfile_rhel_based
@@ -30,8 +30,8 @@ RUN rpmdev-setuptree
 COPY ./packages/rhel-based/omnibus-csghub.spec /root/rpmbuild/SPECS/
 COPY --from=omnibus /opt/. /root/rpmbuild/BUILD/opt
 
-RUN cd /root/rpmbuild/BUILD && mkdir -p etc/systemd && \
-    cp -a opt/csghub/etc/csghub/templates/system etc/systemd/
+RUN cd /root/rpmbuild/BUILD && mkdir -p etc/systemd/system && \
+    cp -a opt/csghub/embedded/etc/csghub/csghub-runsvdir.service etc/systemd/system/
 
 ARG TARGETARCH
 RUN \


### PR DESCRIPTION
…ed layout

The runtime-directories reorg moved the static systemd unit templates/system/csghub-runsvdir.service up to
embedded/etc/csghub/csghub-runsvdir.service. The rpm spec and deb postinst were updated to the new path, but the two packaging Dockerfiles still referenced the deleted path, breaking the deb/rpm build step with 'cannot stat ... templates/system'.

Update both Dockerfile_debian_based and Dockerfile_rhel_based to copy from opt/csghub/embedded/etc/csghub/csghub-runsvdir.service, matching omnibus-csghub.spec and DEBIAN/postinst.