### PR TITLE
chore: remove aliyun apt source override from temporal Dockerfile

### DIFF
--- a/dockerfiles/temporal/Dockerfile_temporal
+++ b/dockerfiles/temporal/Dockerfile_temporal
@@ -12,10 +12,8 @@ WORKDIR /
 
 ENV GOPROXY=https://goproxy.cn,direct
 
-RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirrors.aliyun.com/ubuntu/|g; s|http://security.ubuntu.com/ubuntu/|http://mirrors.aliyun.com/ubuntu/|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirrors.aliyun.com/ubuntu-ports|g' /etc/apt/sources.list && \
-    apt update && \
+RUN apt update && \
     apt install --no-install-recommends -y npm && \
-    apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*
 
 RUN git clone --depth 1 https://github.com/temporalio/ui.git && \


### PR DESCRIPTION
temporal Dockerfile does not need aliyun apt source override.

Only 1 file changed: dockerfiles/temporal/Dockerfile_temporal (+1/-3)