### PR TITLE
fix(temporal): upgrade Node/pnpm for temporal-ui v2.48.4 and fix auth.go patch

### DIFF
--- a/dockerfiles/temporal/Dockerfile_temporal
+++ b/dockerfiles/temporal/Dockerfile_temporal
@@ -7,18 +7,27 @@ FROM ${REGISTRY}/temporalio/auto-setup:${TEMPORAL_VERSION} AS temporal
 
 FROM ${REGISTRY}/temporalio/ui:${TEMPORAL_UI_VERSION} AS temporal_ui
 
-FROM ${REGISTRY}/golang:1.24.2 AS builder
+FROM ${REGISTRY}/golang:1.24.11 AS builder
 WORKDIR /
 
 ENV GOPROXY=https://goproxy.cn,direct
+ARG TEMPORAL_UI_VERSION
 
-RUN apt update && \
-    apt install --no-install-recommends -y npm && \
+RUN if grep -q -i -E 'debian' /etc/os-release; then \
+        find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i \
+          's|https\?://deb.debian.org/debian-security|http://mirrors.aliyun.com/debian-security|g; s|https\?://deb.debian.org/debian|http://mirrors.aliyun.com/debian|g' {} +; \
+    fi && \
+    apt update && \
+    apt install -y --no-install-recommends curl ca-certificates gcc g++ make && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt install -y --no-install-recommends nodejs && \
+    corepack enable && corepack prepare pnpm@latest --activate && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*
 
-RUN git clone --depth 1 https://github.com/temporalio/ui.git && \
-    cd /ui && sed -i '32d;192,200d' server/server/route/auth.go && \
-    npm install -g pnpm@8.15.7 && \
+RUN git clone --depth 1 --branch v${TEMPORAL_UI_VERSION} https://github.com/temporalio/ui.git && \
+    cd /ui && sed -i '32d' server/server/route/auth.go && \
+    sed -i '46s/.*/func validateReturnURL(returnURL string, allowedOrigins []string, requestHost string) error { return nil }/' server/server/route/auth.go && \
+    sed -i '47,71d' server/server/route/auth.go && \
     pnpm install && git submodule update && \
     pnpm build:local && pnpm build:server && \
     cd server && \
@@ -43,7 +52,6 @@ COPY --from=temporal /etc/temporal/config/. ${CSGHUB_HOME}/etc/temporal/config/
 COPY --from=temporal /etc/temporal/schema/. ${CSGHUB_HOME}/etc/temporal/schema/.
 COPY --from=temporal_ui /home/ui-server/ui-server ${CSGHUB_SRV_HOME}/temporal_ui/bin/
 COPY --from=temporal_ui /home/ui-server/config/. ${CSGHUB_HOME}/etc/temporal_ui/config/
-COPY --from=temporal_ui /home/ui-server/config-template.yaml ${CSGHUB_HOME}/etc/temporal_ui/
 COPY --from=builder /ui-server ${CSGHUB_SRV_HOME}/temporal_ui/bin/
 
 RUN find /opt/csghub/etc/temporal -type f -exec sed -i 's|/etc/temporal|/opt/csghub/etc/temporal|g' {} \;


### PR DESCRIPTION
## Summary
- Upgrade Node from 18 to 22 via nodesource (temporal-ui v2.48.4 requires >=22.14.0)
- Use corepack to activate latest pnpm (requires >=10.10.0)
- Fix auth.go sed patch for v2.48.4 to skip validateReturnURL hostname check
- Switch apt to Aliyun mirror for build speed

## Test plan
- [ ] Build temporal image with `docker buildx build --platform linux/arm64,linux/amd64 ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)