### PR TITLE
fix(temporal-ui): update docker.yaml.sample for v2.48.4 and fix config path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,9 +132,7 @@ COPY --from=temporal ${CSGHUB_HOME}/etc/temporal/. ${CSGHUB_EMBEDDED}/etc/tempor
 COPY --from=temporal ${CSGHUB_SRV_HOME}/temporal/. ${CSGHUB_SRV_HOME}/temporal/
 COPY --from=temporal ${CSGHUB_HOME}/etc/temporal_ui/. ${CSGHUB_EMBEDDED}/etc/temporal_ui/
 COPY --from=temporal ${CSGHUB_SRV_HOME}/temporal_ui/. ${CSGHUB_SRV_HOME}/temporal_ui/
-
-# Using 8182 as temporal-ui default listen port
-RUN sed -i 's/8080/8182/g' ${CSGHUB_EMBEDDED}/etc/temporal_ui/config-template.yaml
+COPY ./opt/csghub/embedded/etc/temporal_ui/. ${CSGHUB_EMBEDDED}/etc/temporal_ui/
 
 # Remap temporal internal paths from component image to new embedded location
 RUN find ${CSGHUB_EMBEDDED}/etc/temporal -type f -exec sed -i 's|/opt/csghub/etc/temporal|/opt/csghub/embedded/etc/temporal|g' {} \;

--- a/ee.Dockerfile
+++ b/ee.Dockerfile
@@ -150,6 +150,7 @@ COPY --from=temporal ${CSGHUB_HOME}/etc/temporal/. ${CSGHUB_EMBEDDED}/etc/tempor
 COPY --from=temporal ${CSGHUB_SRV_HOME}/temporal/. ${CSGHUB_SRV_HOME}/temporal/
 COPY --from=temporal ${CSGHUB_HOME}/etc/temporal_ui/. ${CSGHUB_EMBEDDED}/etc/temporal_ui/
 COPY --from=temporal ${CSGHUB_SRV_HOME}/temporal_ui/. ${CSGHUB_SRV_HOME}/temporal_ui/
+COPY ./opt/csghub/embedded/etc/temporal_ui/. ${CSGHUB_EMBEDDED}/etc/temporal_ui/
 
 ## Install NATS
 COPY --from=nats /nats-server ${CSGHUB_SRV_HOME}/nats/bin/
@@ -191,8 +192,7 @@ COPY --from=frontend /usr/share/nginx/html ${CSGHUB_EMBEDDED}/etc/nginx/html
 COPY --from=agentic /code/. ${CSGHUB_SRV_HOME}/agentic/
 
 # Using 8182 as temporal-ui default listen port
-RUN sed -i 's/8080/8182/g' ${CSGHUB_EMBEDDED}/etc/temporal_ui/config-template.yaml && \
-    sed -i -e 's/:8000/:8183/g' \
+RUN sed -i -e 's/:8000/:8183/g' \
       -e 's|/code/logs/gunicorn.access.log|/dev/stdout|g' \
       -e 's|/code/|/opt/csghub/embedded/sv/web/|g' \
       ${CSGHUB_EMBEDDED}/sv/web/project/{gunicorn_config.py,uwsgi.ini}

--- a/opt/csghub/embedded/etc/temporal_ui/docker.yaml.sample
+++ b/opt/csghub/embedded/etc/temporal_ui/docker.yaml.sample
@@ -3,22 +3,23 @@ temporalGrpcAddress: {{ printf "%s:%d" .temporal.rpc.bind_on_ip .temporal.rpc.gr
 port: {{ .temporal_ui.listen_port }}
 publicPath: {{ .temporal_ui.public_path }}
 enableUi: true
-bannerText:
 cloudUi: false
 defaultNamespace: default
 feedbackUrl:
-notifyOnNewVersion: true
 refreshInterval: 0s
-showTemporalSystemNamespace:
-  false
+showTemporalSystemNamespace: false
 disableWriteActions: false
 workflowTerminateDisabled: false
 workflowCancelDisabled: false
 workflowSignalDisabled: false
+workflowUpdateDisabled: false
 workflowResetDisabled: false
+workflowPauseDisabled: false
 batchActionsDisabled: false
 startWorkflowDisabled: true
 hideWorkflowQueryErrors: false
+refreshWorkflowCountsDisabled: false
+activityCommandsDisabled: false
 cors:
   cookieInsecure: {{ .temporal_ui.cors.cookie_insecure }}
   allowOrigins:


### PR DESCRIPTION
## Summary
- Sync docker.yaml.sample with v2.48.4 config schema (add missing fields, remove deprecated ones)
- Remove unused port sed (port is now a csghub-ctl template variable)
- Remove redundant config-template.yaml references from Dockerfile/ee.Dockerfile
- Add COPY for local docker.yaml.sample in CE and EE builds

## Files changed
- `opt/csghub/embedded/etc/temporal_ui/docker.yaml.sample` — sync with v2.48.4
- `Dockerfile` — add local COPY for docker.yaml.sample, remove unused sed
- `ee.Dockerfile` — same changes