### PR TITLE
fix(templates): render prometheus metric_keys as TOML array

### DIFF
--- a/ee/opt/csghub/embedded/etc/server/config.toml.sample
+++ b/ee/opt/csghub/embedded/etc/server/config.toml.sample
@@ -304,7 +304,7 @@ cpu_limit_metric = {{ $prometheus.cpu_limit_metric | quote }}
 memory_usage_metric = {{ $prometheus.memory_usage_metric | quote }}
 request_count_metric = {{ $prometheus.request_count_metric | quote }}
 request_latency_metric = {{ $prometheus.request_latency_metric | quote }}
-metric_keys = {{ $prometheus.metric_keys | quote }}
+metric_keys = [{{ range $i, $k := splitList "," $prometheus.metric_keys }}{{ if $i }}, {{ end }}{{ $k | trim | quote }}{{ end }}]
 
 {{- $logcollector := .server.logcollector }}
 [logcollector]

--- a/opt/csghub/embedded/etc/server/config.toml.sample
+++ b/opt/csghub/embedded/etc/server/config.toml.sample
@@ -299,7 +299,7 @@ cpu_limit_metric = {{ $prometheus.cpu_limit_metric | quote }}
 memory_usage_metric = {{ $prometheus.memory_usage_metric | quote }}
 request_count_metric = {{ $prometheus.request_count_metric | quote }}
 request_latency_metric = {{ $prometheus.request_latency_metric | quote }}
-metric_keys = {{ $prometheus.metric_keys | quote }}
+metric_keys = [{{ range $i, $k := splitList "," $prometheus.metric_keys }}{{ if $i }}, {{ end }}{{ $k | trim | quote }}{{ end }}]
 
 {{- $logcollector := .server.logcollector }}
 


### PR DESCRIPTION
metric_keys was rendered as a single quoted comma-separated string. Split it on comma and render each key as a quoted element so the result is a proper TOML array, e.g. ["pod", "service_name", ...]. A trim guards against stray whitespace. Applied to both CE and EE config.toml.sample templates.