### PR TITLE
feat(postgresql): enable pgvector and timescaledb extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
                 ca-certificates \
                 libicu74 \
                 libreadline8t64 \
+                libstdc++6 \
                 netcat-openbsd \
                 libaprutil1t64 \
                 libgeoip1t64 \
@@ -195,6 +196,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
                 ca-certificates \
                 libicu70 \
                 libreadline8 \
+                libstdc++6 \
                 netcat-openbsd \
                 libaprutil1 \
                 libgeoip1 \

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -96,12 +96,16 @@ docker buildx build \
 OS_RELEASE=ubuntu:22.04
 POSTGRESQL_VERSION=16.14
 SCWS_VERSION=1.2.3
+PGVECTOR_VERSION=v0.8.0
+TIMESCALEDB_VERSION=2.28.3
 docker buildx build \
   --provenance false \
   --platform linux/arm64,linux/amd64 \
   --build-arg OS_RELEASE=${OS_RELEASE} \
   --build-arg POSTGRESQL_VERSION=${POSTGRESQL_VERSION} \
   --build-arg SCWS_VERSION=${SCWS_VERSION} \
+  --build-arg PGVECTOR_VERSION=${PGVECTOR_VERSION} \
+  --build-arg TIMESCALEDB_VERSION=${TIMESCALEDB_VERSION} \
   --tag opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/omnibus-csghub:postgresql-${POSTGRESQL_VERSION} \
   --file dockerfiles/postgresql/Dockerfile_postgresql \
   --push .
@@ -114,6 +118,8 @@ docker buildx build \
 OS_RELEASE=ubuntu:22.04
 POSTGRESQL_VERSION=16.14
 SCWS_VERSION=1.2.3
+PGVECTOR_VERSION=v0.8.0
+TIMESCALEDB_VERSION=2.28.3
 PYTHON_VERSION=3.11.11
 PATRONI_VERSION=4.0.5
 docker buildx build \
@@ -122,6 +128,8 @@ docker buildx build \
   --build-arg OS_RELEASE=${OS_RELEASE} \
   --build-arg POSTGRESQL_VERSION=${POSTGRESQL_VERSION} \
   --build-arg SCWS_VERSION=${SCWS_VERSION} \
+  --build-arg PGVECTOR_VERSION=${PGVECTOR_VERSION} \
+  --build-arg TIMESCALEDB_VERSION=${TIMESCALEDB_VERSION} \
   --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
   --build-arg PATRONI_VERSION=${PATRONI_VERSION} \
   --tag opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/omnibus-csghub:patroni-${PATRONI_VERSION} \

--- a/dockerfiles/patroni/Dockerfile_patroni
+++ b/dockerfiles/patroni/Dockerfile_patroni
@@ -20,6 +20,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
           libssl-dev \
           zlib1g-dev \
           pkg-config \
+          cmake \
           ca-certificates && \
         apt clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*; \
@@ -32,6 +33,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
               openssl-devel \
               zlib-devel \
               pkgconfig \
+              cmake \
               ca-certificates && \
             dnf clean all; \
         else \
@@ -42,6 +44,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
               openssl-devel \
               zlib-devel \
               pkgconfig \
+              cmake \
               ca-certificates && \
             yum clean all; \
         fi; \
@@ -70,6 +73,17 @@ RUN wget http://www.xunsearch.com/scws/down/scws-${SCWS_VERSION}.tar.bz2 && \
 ENV SCWS_HOME=${CSGHUB_EMBEDDED}
 RUN git clone https://github.com/amutu/zhparser.git && \
     cd /zhparser && make -j2&& make install
+
+# Build pgvector extension (disable -march=native to avoid miscompilation on arm64)
+ARG PGVECTOR_VERSION=v0.8.0
+RUN git clone --branch ${PGVECTOR_VERSION} https://github.com/pgvector/pgvector.git && \
+    cd /pgvector && make OPTFLAGS="" && make install
+
+# Build timescaledb extension
+ARG TIMESCALEDB_VERSION=2.28.3
+RUN git clone --depth 1 --branch ${TIMESCALEDB_VERSION} https://github.com/timescale/timescaledb.git && \
+    cd /timescaledb && ./bootstrap -DCMAKE_BUILD_TYPE=Release -DAPACHE_ONLY=true && \
+    cd build && make -j$(nproc) && make install
 
 ## Install Python
 RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \

--- a/dockerfiles/patroni/version-manifests.json
+++ b/dockerfiles/patroni/version-manifests.json
@@ -9,6 +9,8 @@
           "OS_RELEASE": "ubuntu:22.04",
           "POSTGRESQL_VERSION": "16.14",
           "SCWS_VERSION": "1.2.3",
+          "PGVECTOR_VERSION": "v0.8.0",
+          "TIMESCALEDB_VERSION": "2.28.3",
           "PYTHON_VERSION": "3.11.11",
           "PATRONI_VERSION": "4.0.5"
         }

--- a/dockerfiles/postgresql/Dockerfile_postgresql
+++ b/dockerfiles/postgresql/Dockerfile_postgresql
@@ -20,6 +20,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
           libssl-dev \
           zlib1g-dev \
           pkg-config \
+          cmake \
           ca-certificates && \
         apt clean && \
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*; \
@@ -32,6 +33,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
               openssl-devel \
               zlib-devel \
               pkgconfig \
+              cmake \
               ca-certificates && \
             dnf clean all; \
         else \
@@ -42,6 +44,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
               openssl-devel \
               zlib-devel \
               pkgconfig \
+              cmake \
               ca-certificates && \
             yum clean all; \
         fi; \
@@ -70,6 +73,17 @@ RUN wget http://www.xunsearch.com/scws/down/scws-${SCWS_VERSION}.tar.bz2 && \
 ENV SCWS_HOME=${CSGHUB_EMBEDDED}
 RUN git clone https://github.com/amutu/zhparser.git && \
     cd /zhparser && make && make install
+
+# Build pgvector extension (disable -march=native to avoid miscompilation on arm64)
+ARG PGVECTOR_VERSION=v0.8.0
+RUN git clone --branch ${PGVECTOR_VERSION} https://github.com/pgvector/pgvector.git && \
+    cd /pgvector && make OPTFLAGS="" && make install
+
+# Build timescaledb extension
+ARG TIMESCALEDB_VERSION=2.28.3
+RUN git clone --depth 1 --branch ${TIMESCALEDB_VERSION} https://github.com/timescale/timescaledb.git && \
+    cd /timescaledb && ./bootstrap -DCMAKE_BUILD_TYPE=Release -DAPACHE_ONLY=true && \
+    cd build && make -j$(nproc) && make install
 
 FROM ${REGISTRY}/${OS_RELEASE}
 

--- a/dockerfiles/postgresql/version-manifests.json
+++ b/dockerfiles/postgresql/version-manifests.json
@@ -8,7 +8,9 @@
         "environments": {
           "OS_RELEASE": "ubuntu:22.04",
           "POSTGRESQL_VERSION": "16.14",
-          "SCWS_VERSION": "1.2.3"
+          "SCWS_VERSION": "1.2.3",
+          "PGVECTOR_VERSION": "v0.8.0",
+          "TIMESCALEDB_VERSION": "2.28.3"
         }
       }
     ]

--- a/ee.Dockerfile
+++ b/ee.Dockerfile
@@ -210,6 +210,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
                 ca-certificates \
                 libicu74 \
                 libreadline8t64 \
+                libstdc++6 \
                 netcat-openbsd \
                 libaprutil1t64 \
                 libgeoip1t64 \
@@ -226,6 +227,7 @@ RUN if grep -q -i -E 'ubuntu|debian' /etc/os-release; then \
                 ca-certificates \
                 libicu70 \
                 libreadline8 \
+                libstdc++6 \
                 netcat-openbsd \
                 libaprutil1 \
                 libgeoip1 \

--- a/ee/opt/csghub/embedded/etc/csghub/default.yaml
+++ b/ee/opt/csghub/embedded/etc/csghub/default.yaml
@@ -634,7 +634,7 @@ postgresql:
   max_connections: 200                                     ## Max connections
   shared_buffers: "256MB"                                  ## Shared memory buffers
   timezone: "Asia/Shanghai"                                ## Database timezone
-  shared_preload_libraries: "pg_stat_statements,zhparser"  ## Preloaded extensions (comma-separated)
+  shared_preload_libraries: "pg_stat_statements,zhparser,timescaledb"  ## Preloaded extensions (comma-separated)
   log_statement: "none"                                    ## Log all SQL statements (off|ddl|mod|all)
   log_checkpoints: "off"                                   ## Log checkpoint operations
   log_connections: "off"                                   ## Log connections
@@ -694,6 +694,7 @@ patroni:
     ## PostgreSQL Parameters
     parameters:
       shared_buffers: "256MB"   ## Shared memory buffers size
+      shared_preload_libraries: "pg_stat_statements,zhparser,timescaledb"  ## Preloaded extensions (comma-separated)
 
     pgpass: "/var/opt/csghub/patroni/.pgpass"   ## Password file path
 

--- a/ee/opt/csghub/embedded/etc/csghub/templates/csghub.yaml.sample
+++ b/ee/opt/csghub/embedded/etc/csghub/templates/csghub.yaml.sample
@@ -626,7 +626,7 @@ csghub:
   # max_connections: 200                                     ## Max connections
   # shared_buffers: "256MB"                                  ## Shared memory buffers
   # timezone: "Asia/Shanghai"                                ## Database timezone
-  # shared_preload_libraries: "pg_stat_statements,zhparser"  ## Preloaded extensions (comma-separated)
+  # shared_preload_libraries: "pg_stat_statements,zhparser,timescaledb"  ## Preloaded extensions (comma-separated)
   # log_statement: "none"                                    ## Log all SQL statements (off|ddl|mod|all)
   # log_checkpoints: "off"                                   ## Log checkpoint operations
   # log_connections: "off"                                   ## Log connections

--- a/opt/csghub/embedded/etc/csghub/default.yaml
+++ b/opt/csghub/embedded/etc/csghub/default.yaml
@@ -447,7 +447,7 @@ postgresql:
   max_connections: 200                                     ## Max connections
   shared_buffers: "256MB"                                  ## Shared memory buffers
   timezone: "Asia/Shanghai"                                ## Database timezone
-  shared_preload_libraries: "pg_stat_statements,zhparser"  ## Preloaded extensions (comma-separated)
+  shared_preload_libraries: "pg_stat_statements,zhparser,timescaledb"  ## Preloaded extensions (comma-separated)
   log_statement: "none"                                    ## Log all SQL statements (off|ddl|mod|all)
   log_checkpoints: "off"                                   ## Log checkpoint operations
   log_connections: "off"                                   ## Log connections

--- a/opt/csghub/embedded/etc/csghub/templates/csghub.yaml.sample
+++ b/opt/csghub/embedded/etc/csghub/templates/csghub.yaml.sample
@@ -439,7 +439,7 @@ csghub:
   # max_connections: 200                                     ## Max connections
   # shared_buffers: "256MB"                                  ## Shared memory buffers
   # timezone: "Asia/Shanghai"                                ## Database timezone
-  # shared_preload_libraries: "pg_stat_statements,zhparser"  ## Preloaded extensions (comma-separated)
+  # shared_preload_libraries: "pg_stat_statements,zhparser,timescaledb"  ## Preloaded extensions (comma-separated)
   # log_statement: "none"                                    ## Log all SQL statements (off|ddl|mod|all)
   # log_checkpoints: "off"                                   ## Log checkpoint operations
   # log_connections: "off"                                   ## Log connections


### PR DESCRIPTION
## Summary
Enable pgvector and timescaledb extensions in the embedded PostgreSQL for both CE and EE builds.

## Changes
- **Dockerfiles** (`postgresql`, `patroni`): build pgvector v0.8.0 and timescaledb 2.28.3 from source
  - `make OPTFLAGS=""` disables `-march=native` to avoid arm64 miscompilation
  - timescaledb built with `-DAPACHE_ONLY=true`
- **Build deps**: add `cmake` (required by timescaledb)
- **Runtime deps**: add `libstdc++6` (timescaledb is C++, needs libstdc++)
- **Config**: preload `timescaledb` via `shared_preload_libraries` in CE/EE `default.yaml` and patroni parameters
- **Docs/manifests**: record new extension versions

## Test plan
- [ ] Build postgresql image: `docker buildx build --platform linux/arm64,linux/amd64 ...`
- [ ] `CREATE EXTENSION vector;` works
- [ ] `CREATE EXTENSION timescaledb;` works