### PR TITLE
fix(build): decouple csghub-server/portal versions from omnibus release tag

### DIFF
--- a/.gitlab/.omnibus.gitlab-ci.yml
+++ b/.gitlab/.omnibus.gitlab-ci.yml
@@ -58,8 +58,11 @@ build-omnibus-$[[ inputs.tag ]]:
   script:
     - |
       cat <<'EOF' | bash -s
-      # Collect build parameters for all components
-      BUILD_ARGS=$(jq -r '.version_manifest.components[] | "--build-arg \(.name | ascii_upcase | gsub("-"; "_"))_VERSION=\(.version)"' opt/csghub/version-manifests.json | tr '\n' ' ')
+      # Collect build parameters for all components.
+      # csghub-server/csghub-portal are excluded from the manifest-driven args:
+      # their versions are pinned separately (default = omnibus release tag) so a
+      # patch release can keep them on the previous minor if desired.
+      BUILD_ARGS=$(jq -r '.version_manifest.components[] | select(.name != "csghub-server" and .name != "csghub-portal") | "--build-arg \(.name | ascii_upcase | gsub("-"; "_"))_VERSION=\(.version)"' opt/csghub/version-manifests.json | tr '\n' ' ')
 
       OS_TAG=$(basename $OS_RELEASE | sed 's/:/_/g')
       BUILD_ARGS+=(
@@ -67,6 +70,10 @@ build-omnibus-$[[ inputs.tag ]]:
         "--build-arg" "OS_TAG=${OS_TAG}"
         "--build-arg" "REGISTRY=${REGISTRY}"
         "--build-arg" "CSGHUB_VERSION=${CI_COMMIT_TAG}"
+        # server/portal follow the omnibus tag by default; override via CI variables
+        # (e.g. CSGHUB_SERVER_VERSION=v2.3.0-ce) to pin them on patch releases.
+        "--build-arg" "CSGHUB_SERVER_VERSION=${CSGHUB_SERVER_VERSION:-${CI_COMMIT_TAG}}"
+        "--build-arg" "CSGHUB_PORTAL_VERSION=${CSGHUB_PORTAL_VERSION:-${CI_COMMIT_TAG}}"
       )
 
       IMAGE="${ACR_REGISTRY}/opencsghq/omnibus-csghub:${CI_COMMIT_TAG}-${OS_TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG OS_RELEASE=ubuntu:22.04
 ARG OS_TAG=ubuntu_22.04
 
 ARG CSGHUB_VERSION=v2.3.0-ce
+ARG CSGHUB_SERVER_VERSION=v2.3.0-ce
+ARG CSGHUB_PORTAL_VERSION=v2.3.0-ce
 ARG RUNIT_VERSION=2.3.1
 ARG TOOLBOX_VERSION=1.4.2
 ARG CONSUL_VERSION=1.20.5
@@ -61,10 +63,10 @@ FROM ${REGISTRY}/casbin/casdoor:${CASDOOR_VERSION} AS casdoor
 FROM ${GITLAB_REGISTRY}/omnibus-nginx:${NGINX_VERSION}-${OS_TAG} AS nginx
 
 ## Install csghub-server
-FROM ${REGISTRY}/csghub-server:${CSGHUB_VERSION} AS server
+FROM ${REGISTRY}/csghub-server:${CSGHUB_SERVER_VERSION} AS server
 
 ## Install csghub-portal
-FROM ${REGISTRY}/csghub-portal:${CSGHUB_VERSION} AS portal
+FROM ${REGISTRY}/csghub-portal:${CSGHUB_PORTAL_VERSION} AS portal
 
 ## Install Prometheus
 FROM ${REGISTRY}/prom/prometheus:${PROM_VERSION} AS prometheus

--- a/ee.Dockerfile
+++ b/ee.Dockerfile
@@ -4,6 +4,8 @@ ARG OS_RELEASE=ubuntu:22.04
 ARG OS_TAG=ubuntu_22.04
 
 ARG CSGHUB_VERSION=v2.3.0-ee
+ARG CSGHUB_SERVER_VERSION=v2.3.0-ee
+ARG CSGHUB_PORTAL_VERSION=v2.3.0-ee
 ARG RUNIT_VERSION=2.3.1
 ARG TOOLBOX_VERSION=1.4.2
 ARG CONSUL_VERSION=1.20.5
@@ -66,10 +68,10 @@ FROM ${REGISTRY}/casbin/casdoor:${CASDOOR_VERSION} AS casdoor
 FROM ${GITLAB_REGISTRY}/omnibus-nginx:${NGINX_VERSION}-${OS_TAG} AS nginx
 
 ## Install csghub-server
-FROM ${REGISTRY}/csghub-server:${CSGHUB_VERSION} AS server
+FROM ${REGISTRY}/csghub-server:${CSGHUB_SERVER_VERSION} AS server
 
 ## Install csghub-portal
-FROM ${REGISTRY}/csghub-portal:${CSGHUB_VERSION} AS portal
+FROM ${REGISTRY}/csghub-portal:${CSGHUB_PORTAL_VERSION} AS portal
 
 ## Install csghub-xnet
 FROM ${REGISTRY}/csghub-xnet:${XNET_VERSION} AS xnet


### PR DESCRIPTION
## Summary

`csghub-server` and `csghub-portal` are now pulled via dedicated `CSGHUB_SERVER_VERSION` / `CSGHUB_PORTAL_VERSION` build args instead of reusing `CSGHUB_VERSION`. This decouples their versions from the omnibus release tag.

## Why

The omnibus release version (`CSGHUB_VERSION`) and the server/portal component versions usually move together on **minor** releases, but on **patch** releases the server/portal often stay pinned at the previous minor while the omnibus script/component changes bump the release number.

Previously, since the Dockerfiles used `${CSGHUB_VERSION}` for the server/portal `FROM`, a patch release like `v2.3.1-ce` would incorrectly try to pull `csghub-server:v2.3.1-ce` / `csghub-portal:v2.3.1-ce`.

## Changes

- **`Dockerfile` / `ee.Dockerfile`**: add `CSGHUB_SERVER_VERSION` and `CSGHUB_PORTAL_VERSION` ARGs (defaulting to `v2.3.0-ce` / `v2.3.0-ee` respectively) and use them in the `FROM` lines. `CSGHUB_VERSION` remains as the omnibus release number only.
- **`.gitlab/.omnibus.gitlab-ci.yml`**: exclude `csghub-server`/`csghub-portal` from the manifest-driven `BUILD_ARGS`, and pass the two new args explicitly, defaulting to the release tag:
  ```bash
  --build-arg CSGHUB_SERVER_VERSION=${CSGHUB_SERVER_VERSION:-${CI_COMMIT_TAG}}
  --build-arg CSGHUB_PORTAL_VERSION=${CSGHUB_PORTAL_VERSION:-${CI_COMMIT_TAG}}
  ```

## Release workflow

| Scenario | Action | server/portal pulled |
|---|---|---|
| Minor release (e.g. v2.4.0-ce) | tag as usual, nothing to change | auto-follows → v2.4.0-ce |
| Patch release (e.g. v2.3.1-ce, server/portal unchanged) | web pipeline with `CSGHUB_SERVER_VERSION=v2.3.0-ce`, `CSGHUB_PORTAL_VERSION=v2.3.0-ce` | pinned to v2.3.0-ce |
| Local `docker build` | no args | falls back to Dockerfile defaults |

## Verification

- jq filter / shell parameter expansion simulated for both default and override cases
- YAML parses as valid GitLab CI (2 documents for `spec: inputs:`)
- Dockerfiles pass `docker buildx build --check` frontend parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)